### PR TITLE
Do not overwirte keyboard highlights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,7 +258,16 @@ function App() {
 		);
 		data.result?.forEach((colour, i) => {
 			const letter = currentGuess[i];
-			newLetterStates[letter] = colour;
+			if (letterStateHistory[letter] !== "green") {
+				if (letterStateHistory[letter] === "yellow" && colour !== "grey") {
+					newLetterStates[letter] = colour;
+				} else if (
+					letterStateHistory[letter] === "grey" ||
+					!letterStateHistory[letter]
+				) {
+					newLetterStates[letter] = colour;
+				}
+			}
 		});
 
 		setLetterStateHistory(newLetterStates);


### PR DESCRIPTION
Previously the keyboard would overwrite green keys with yellows if the letter was in the next word but not in the right position, this pr prevents this from happening